### PR TITLE
treesitter: Add injection for rust doc-comments

### DIFF
--- a/queries/rust/injections.scm
+++ b/queries/rust/injections.scm
@@ -1,0 +1,6 @@
+((line_comment) @_first
+ (_) @rust
+ (line_comment) @_last
+ (#match? @_first "^/// ```$")
+ (#match? @_last "^/// ```$")
+ (#offset! @rust 0 4 0 4))


### PR DESCRIPTION
Add injections at `queries/rust/injections.scm`
that highlight rust source code in doc comments
using rust parser.
